### PR TITLE
Prevent NOMAD_VAR_SLUG from ending in hyphen

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -109,7 +109,7 @@ function main() {
   if [ ! $MAIN_OR_PROD_OR_STAGING_OR_EXT_SLUG ]; then
     export BRANCH_PART="-${CI_COMMIT_REF_SLUG}"
   fi
-  export NOMAD_VAR_SLUG=$(echo "${CI_PROJECT_PATH_SLUG}${BRANCH_PART}" |cut -b1-63)
+  export NOMAD_VAR_SLUG=$(echo "${CI_PROJECT_PATH_SLUG}${BRANCH_PART}" |cut -b1-63 | sed 's/-$//')
   # make nice (semantic) hostname, based on the slug, eg:
   #   services-timemachine.x.archive.org
   #   ia-petabox-webdev-3939-fix-things.x.archive.org


### PR DESCRIPTION
This commit is intended to address the situation where a branch name longer than 63 characters is truncated in a way such that it ends with a hyphen. See, e.g.
```
$ /deploy.shusing nomad cluster https://dev.archive.org
deploying to
https://www-offshoot-webdev-7307-adjust-banner-image-sizing-collection-.dev.archive.org
+ nomad validate -var-file=env.env project.hcl
Job validation errors:1
error occurred:
    * Task group service validation failed: 1 error occurred:
    * Service name must be valid per RFC 1123 and can contain only
alphanumeric characters or dashes and must be no longer than 63
characters:
"www-offshoot-webdev-7307-adjust-banner-image-sizing-collection-"
```