### PR TITLE
Don't bother rsyncing if VSCode sync-rsync.remotePath is empty

### DIFF
--- a/aliases
+++ b/aliases
@@ -109,6 +109,7 @@ function nom-cp() {
   done
   echo
 
+  # If called by VSCode and sync-rsync.sites.remotePath is not "", try to rsync
   if [ $VSCODE ] && [ "/$REST" != "${@: -1}" ]; then
     local MAIN=
     [ "$BRANCH" = "main"   ]  &&  MAIN=true

--- a/aliases
+++ b/aliases
@@ -109,7 +109,7 @@ function nom-cp() {
   done
   echo
 
-  if [ $VSCODE ]; then
+  if [ $VSCODE ] && [ "/$REST" != "${@: -1}" ]; then
     local MAIN=
     [ "$BRANCH" = "main"   ]  &&  MAIN=true
     [ "$BRANCH" = "master" ]  &&  MAIN=true


### PR DESCRIPTION
Sorry, one last touch which makes VSCode see an exit 0 from vsync if we don't intend to rsync and signal that by setting sync-rsync.remotePath to ""